### PR TITLE
Adjust mobile viewport height for mobile layout

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -126,9 +126,11 @@ input:focus {
 @media (max-width: 600px) {
   body {
     padding: 1.5rem 1rem;
+    min-height: 90vh;
   }
 
   .app {
     padding: 2rem 1.5rem;
+    min-height: 90vh;
   }
 }


### PR DESCRIPTION
## Summary
- ensure the body and app containers use a 90vh minimum height on narrow viewports
- keep the existing mobile spacing adjustments while honoring the requested height

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68dd95f2c270832eaa97562cc69428e4